### PR TITLE
Fixed bug in Windows

### DIFF
--- a/src/main/java/net/didion/jwnl/princeton/file/PrincetonObjectDictionaryFile.java
+++ b/src/main/java/net/didion/jwnl/princeton/file/PrincetonObjectDictionaryFile.java
@@ -64,7 +64,7 @@ public class PrincetonObjectDictionaryFile extends AbstractPrincetonDictionaryFi
 	}
 
 	private void openInputStream() throws IOException {
-		_in = new ObjectInputStream(PrincetonObjectDictionaryFile.class.getResourceAsStream(_file.getPath()));
+		_in = new ObjectInputStream(PrincetonObjectDictionaryFile.class.getResourceAsStream(_file.getPath().replace('\\', '/')));
 	}
 
 	public ObjectInputStream getInputStream() throws IOException {
@@ -111,7 +111,7 @@ public class PrincetonObjectDictionaryFile extends AbstractPrincetonDictionaryFi
 	 */
 	protected void openFile(File path) throws IOException {
 		_file = path;
-		if (!_file.exists() && PrincetonObjectDictionaryFile.class.getResource(path.getPath()) == null) {
+		if (!_file.exists() && PrincetonObjectDictionaryFile.class.getResource(path.getPath().replace('\\', '/')) == null) {
 			_file.createNewFile();
 			openOutputStream();
 		} else {


### PR DESCRIPTION
Could not load binary dictionary file from classpath due to wrong path slashes
@danyaljj I would like this merged/versioned/merged and integrated into `illinois-core-utilities` as soon as possible.
